### PR TITLE
Move consent screen a bit lower

### DIFF
--- a/plugins/discourse-edgeryders/assets/stylesheets/consent.scss
+++ b/plugins/discourse-edgeryders/assets/stylesheets/consent.scss
@@ -5,6 +5,7 @@
 */
 #consent-panel {
   margin-right: 20px;
+  margin-top: 15px;
 
   .card {
     padding: 8px;


### PR DESCRIPTION
Just a small change that doesn't hide the text at the very top :). Also a small note that you can't search on any code because it's a fork. Perhaps you want to keep it a fork so you can easily use the changes from upstream?


