### PR TITLE
Render correct status with failed account creation

### DIFF
--- a/plugins/edgeryders-multisite-accounts/plugin.rb
+++ b/plugins/edgeryders-multisite-accounts/plugin.rb
@@ -47,7 +47,7 @@ after_initialize do
         return render_json_error("edgeryders_research_consent: Edgeryders research consent is required.")
       end
       response = create_sso_provider_account
-      return render json: response unless response['success']
+      return render json: response, status: :unprocessable_entity unless response['success']
       sso_provider_user = User.find_by(username: params[:username])
       api_keys = params[:requested_api_keys].split(' ').map do |hostname|
         create_community_account(hostname: hostname, sso_provider_user: sso_provider_user)


### PR DESCRIPTION
Currently an unsuccessful account creation results in a 200 status, which shouldn't be the case. This updates the status to be 422 in the event that the Discourse API call returns false for whatever reason (the errors will continue to be rendered out in the response as expected).